### PR TITLE
Support more RDS parameters via datastore module update

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The examples do require access to an eks-cluster via the `eks_cluster_name` vari
 
 | Name | Source | Version |
 |------|--------|---------|
-| service_datastore | git::git@github.com:hyprnz/terraform-aws-data-storage-module | 3.0.1 |
+| service_datastore | git::git@github.com:hyprnz/terraform-aws-data-storage-module | 3.1.0 |
 
 ## Inputs
 

--- a/datastore.tf
+++ b/datastore.tf
@@ -1,5 +1,5 @@
 module "service_datastore" {
-  source = "git::git@github.com:hyprnz/terraform-aws-data-storage-module?ref=3.0.1"
+  source = "git::git@github.com:hyprnz/terraform-aws-data-storage-module?ref=3.1.0"
 
   providers = {
     aws = aws

--- a/datastore.tf
+++ b/datastore.tf
@@ -1,5 +1,5 @@
 module "service_datastore" {
-  source = "git::git@github.com:hyprnz/terraform-aws-data-storage-module?ref=3.0.0"
+  source = "git::git@github.com:hyprnz/terraform-aws-data-storage-module?ref=3.0.1"
 
   providers = {
     aws = aws
@@ -28,13 +28,17 @@ module "service_datastore" {
   rds_max_allocated_storage = var.rds_max_allocated_storage
   rds_iops                  = var.rds_iops
 
-  backup_retention_period = var.backup_retention_period
-  rds_option_group_name   = var.rds_option_group_name
-  rds_multi_az            = var.rds_multi_az
+  backup_retention_period        = var.backup_retention_period
+  rds_option_group_name          = var.rds_option_group_name
+  rds_parameter_group_name       = var.rds_parameter_group_name
+  rds_parameter_group_family     = var.rds_parameter_group_family
+  rds_parameter_group_parameters = var.rds_parameter_group_parameters
+  rds_multi_az                   = var.rds_multi_az
 
   rds_monitoring_interval         = var.rds_monitoring_interval
   rds_monitoring_role_arn         = var.rds_monitoring_role_arn
   rds_enable_performance_insights = var.rds_enable_performance_insights
+  rds_cloudwatch_logs_exports     = var.rds_cloudwatch_logs_exports
 
   rds_backup_window             = var.rds_backup_window
   rds_skip_final_snapshot       = var.rds_skip_final_snapshot
@@ -45,6 +49,8 @@ module "service_datastore" {
 
   rds_username = var.rds_username
   rds_password = var.rds_password
+
+  rds_iam_authentication_enabled = var.rds_iam_authentication_enabled
 
   rds_enable_deletion_protection = var.rds_enable_deletion_protection
 

--- a/examples/rds_datastore/main.tf
+++ b/examples/rds_datastore/main.tf
@@ -56,6 +56,14 @@ module "example" {
 
   rds_subnet_group       = aws_db_subnet_group.db_subnetgroup.name
   rds_security_group_ids = [aws_security_group.db_security_group.id]
+
+  rds_parameter_group_name = "example-dev-parameter-group"
+  rds_parameter_group_family = "postgres11"
+  rds_parameter_group_parameters = {
+    "log_connections": "1",
+    "log_disconnections": "1",
+    "shared_preload_libraries": "pg_stat_statements,pgaudit"
+  }
 }
 
 provider "aws" {

--- a/vars.tf
+++ b/vars.tf
@@ -247,6 +247,36 @@ variable "rds_enable_deletion_protection" {
   default     = false
 }
 
+variable "rds_parameter_group_name" {
+  type        = string
+  description = "Name of the DB parameter group to create and associate with the instance"
+  default     = null
+}
+
+variable "rds_parameter_group_family" {
+  type        = string
+  description = "Name of the DB family (engine & version) for the parameter group. eg. postgres11"
+  default     = null
+}
+
+variable "rds_parameter_group_parameters" {
+  type        = map
+  description = "Key value pairs of parameters that will be added to this database's parameter group. Requires `rds_parameter_group_name` and `rds_parameter_group_family` to be set as well. Default is empty and the AWS default parameter group is used."
+  default     = {}
+}
+
+variable "rds_cloudwatch_logs_exports" {
+  type        = set(string)
+  description = "Which RDS logs should be sent to CloudWatch. The default is `postgresql` and `upgrade`."
+  default     = ["postgresql", "upgrade"]
+}
+
+variable "rds_iam_authentication_enabled" {
+  type        = bool
+  description = "Controls whether you can use IAM users to log in to the RDS database. The default is `false`"
+  default     = false
+}
+
 // s3 variables =================================
 
 variable "s3_tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source : "hashicorp/aws",
-      version : ">= 3.38.0"
+      version : ">= 3.38.0, < 4.0.0"
     }
     kubernetes = {
       source : "hashicorp/kubernetes"


### PR DESCRIPTION
Relates to data store module changes here: https://github.com/hyprnz/terraform-aws-data-storage-module/pull/8

**Change notes:**

- Reformatted readme file to include release list and new table of contents
- Capped the aws provider version at < 4.0.0 until we can properly support the new version
- Updated Data Store Module implementation to support new version including:
  - Custom parameter groups
  - Enabling / disabling of IAM authentication
  - Sending RDS logs to CloudWatch by default
- Updated RDS example to include creation of a parameter group
